### PR TITLE
Fix Thai search keyword hi-light

### DIFF
--- a/app/utils/markdown/index.test.ts
+++ b/app/utils/markdown/index.test.ts
@@ -184,6 +184,11 @@ describe('Utility functions', () => {
             const result = convertSearchTermToRegex('你好');
             expect(result.pattern).toEqual(/()(你好)/gi);
         });
+        it('should create regex for Thai characters', () => {
+            const result = convertSearchTermToRegex('สวัสดี');
+            expect(result.pattern).toEqual(/()(สวัสดี)/gi);
+        });
+
 
         it('should create regex for wildcard at the end', () => {
             const result = convertSearchTermToRegex('hello*');

--- a/app/utils/markdown/index.test.ts
+++ b/app/utils/markdown/index.test.ts
@@ -184,11 +184,11 @@ describe('Utility functions', () => {
             const result = convertSearchTermToRegex('你好');
             expect(result.pattern).toEqual(/()(你好)/gi);
         });
+        
         it('should create regex for Thai characters', () => {
             const result = convertSearchTermToRegex('สวัสดี');
             expect(result.pattern).toEqual(/()(สวัสดี)/gi);
         });
-
 
         it('should create regex for wildcard at the end', () => {
             const result = convertSearchTermToRegex('hello*');

--- a/app/utils/markdown/index.ts
+++ b/app/utils/markdown/index.ts
@@ -20,7 +20,7 @@ type LanguageObject = {
 
 // pattern to detect the existence of a Chinese, Japanese, or Korean character in a string
 // http://stackoverflow.com/questions/15033196/using-javascript-to-check-whether-a-string-contains-japanese-characters-includi
-const cjkPattern = /[\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\uff00-\uff9f\u4e00-\u9faf\u3400-\u4dbf\uac00-\ud7a3]/;
+const cjkPattern = /[\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\uff00-\uff9f\u4e00-\u9faf\u3400-\u4dbf\uac00-\ud7a3\u0e00-\u0e7f]/;
 
 const puncStart = /^[^\p{L}\d\s#]+/u;
 const puncEnd = /[^\p{L}\d\s]+$/u;
@@ -347,7 +347,7 @@ export function convertSearchTermToRegex(term: string): SearchPattern {
     let pattern;
 
     if (cjkPattern.test(term)) {
-        // term contains Chinese, Japanese, or Korean characters so don't mark word boundaries
+        // term contains Chinese, Japanese, Korean or Thai characters so don't mark word boundaries
         pattern = '()(' + escapeRegex(term.replace(/\*/g, '')) + ')';
     } else if ((/[^\s][*]$/).test(term)) {
         pattern = '\\b()(' + escapeRegex(term.substring(0, term.length - 1)) + ')';


### PR DESCRIPTION
Previously, Thai search keywords will not be hi-lighted in the search results.

This fix added Thai unicode range into the cjkPattern variable so that Thai search keywords are properly hi-lighted.